### PR TITLE
Current ui review

### DIFF
--- a/lib/features/cards/presentation/screens/home_screen.dart
+++ b/lib/features/cards/presentation/screens/home_screen.dart
@@ -194,6 +194,9 @@ class _HomeScreenState extends State<HomeScreen> {
 
           // Sorting Logic
           final sortedCards = List.of(provider.cards);
+          final now = DateTime.now();
+          final isCurrentMonth = year == now.year && month == now.month;
+
           sortedCards.sort((a, b) {
             final aPaid = PaymentLogic.isPaid(a.paymentDay, year, month);
             final bPaid = PaymentLogic.isPaid(b.paymentDay, year, month);
@@ -202,10 +205,10 @@ class _HomeScreenState extends State<HomeScreen> {
             if (!aPaid && bPaid) return -1;
             if (aPaid && !bPaid) return 1;
 
-            final aApproaching = PaymentLogic.isPaymentDayApproaching(
+            final aApproaching = isCurrentMonth && PaymentLogic.isPaymentDayApproaching(
               a.paymentDay,
             );
-            final bApproaching = PaymentLogic.isPaymentDayApproaching(
+            final bApproaching = isCurrentMonth && PaymentLogic.isPaymentDayApproaching(
               b.paymentDay,
             );
 

--- a/lib/features/cards/presentation/widgets/home_card_item.dart
+++ b/lib/features/cards/presentation/widgets/home_card_item.dart
@@ -29,9 +29,14 @@ class HomeCardItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final isPaymentApproaching = PaymentLogic.isPaymentDayApproaching(
-      card.paymentDay,
-    );
+    final now = DateTime.now();
+    final isCurrentMonth =
+        viewingYear == now.year && viewingMonth == now.month;
+
+    final isPaymentApproaching =
+        isCurrentMonth &&
+        PaymentLogic.isPaymentDayApproaching(card.paymentDay);
+    
     final borderColor =
         isPaymentApproaching
             ? theme.colorScheme.error


### PR DESCRIPTION
Restrict payment approaching UI and sorting logic to only apply when viewing the current month to avoid confusion in past or future views.

---
<a href="https://cursor.com/background-agent?bcId=bc-5aa66df6-4e01-456b-8192-6ed3851256b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5aa66df6-4e01-456b-8192-6ed3851256b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

